### PR TITLE
Update book edition and links

### DIFF
--- a/syllabus.md
+++ b/syllabus.md
@@ -43,9 +43,9 @@ We will be using the following book for the course. It is available in both pape
 
 ####Required
 
-* *Ruby on Rails Tutorial* by Michael Hartl (3rd ED.). The book is available online at
-[http://railstutorial.org/ruby-on-rails-tutorial-book](https://www.railstutorial.org/#pricing)
-, as a PDF from [http://railstutorial.org/](https://www.railstutorial.org/book) ,
+* *Ruby on Rails Tutorial* by Michael Hartl (4th ED.). The book is available online at
+[http://railstutorial.org/book](https://www.railstutorial.org/book)
+, as a PDF from [http://railstutorial.org/](https://www.railstutorial.org) ,
 or as a traditional hard copy from book stores and amazon.com .
 
 ####Optional


### PR DESCRIPTION
The book changed from 3rd to 4th edition, change "book" link to point to online tutorial instead of pricing page.